### PR TITLE
Use a GitHub personal access token for release PR creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,10 @@ jobs:
       - name: Create release
         uses: googleapis/release-please-action@v4
         id: release
+        with:
+          token: ${{ secrets.AUTO_RELEASE_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
 
       - name: Update homebrew-tap
         if: ${{ steps.release.outputs.release_created == 'true' }}


### PR DESCRIPTION
The default GITHUB_TOKEN does not have the permissions needed to create pull requests.