### PR TITLE
Update release instructions and include MIT license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 James Couball
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ To trigger a release:
 
 1. Make your changes and use a [conventional commit](https://www.conventionalcommits.org/) (e.g. `feat: add script xyz`)
 2. Merge to `main`
-3. The GitHub Action will:
-   - Create a release PR
-   - Update the version and SHA256 in the formula
-
+3. The release workflow will create (or update) a release PR
+4. Repeat steps 1-3 until you are ready to release the scripts
+5. Merge the release PR
+   This will trigger the release workflow in jcouball/homebrew-tap
+   
 ## 📄 License
 
 These scripts are MIT licensed unless otherwise stated within individual files.


### PR DESCRIPTION
Revise the release instructions for clarity and add an MIT license to the project.