### PR TITLE
Add ai-prompt and upgrade-all scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .ruby-lsp
+scripts.html

--- a/SCRIPTS.md
+++ b/SCRIPTS.md
@@ -1,0 +1,186 @@
+# Scripts
+
+This document describes the purpose of each script found in the `bin`
+directory.
+
+## ai-prompt
+
+A Ruby script that generates a prompt for an AI model from an ERB
+template. It reads a template file (e.g., `ai-prompt.erb`), processes it
+to include project file contents, and copies the resulting prompt to the
+macOS clipboard using `pbcopy`. It is designed to be run from the root
+of a Git repository.
+
+## bare-prompt
+
+A simple shell script that sets the command line prompt (`PS1`) to a
+minimalist `$ `.
+
+## brew-bundle-dump
+
+Updates the global Homebrew `Brewfile` by running `brew bundle dump`
+with flags to include all installed packages (including Mac App Store
+apps), add descriptions, and overwrite the existing file.
+
+## create-profile-d
+
+A shell script that creates the `/etc/profile.d` directory on macOS if
+it does not already exist. This script requires root privileges to run.
+
+## create-release-pr-labels
+
+Uses the GitHub CLI (`gh`) to create a standard set of labels in a
+repository for managing release pull requests. The labels include
+`major-change`, `minor-change`, `patch-change`, `internal-change`, and
+`release`.
+
+## detect-shell-type
+
+Inspects and reports the current shell\'s environment. It identifies the
+shell executable, determines if the session is interactive and/or a
+login shell, and shows version information for Zsh and Bash.
+
+## dirs-in-my-path
+
+Lists each directory in the `PATH` environment variable on a separate
+line for easy viewing.
+
+## docker-bash
+
+Starts an interactive Bash session within a specified Docker image. It
+can also execute a given command within the container instead of
+starting an interactive shell.
+
+## docker-nuke
+
+Completely resets the local Docker environment by stopping all running
+containers, then forcibly pruning all containers, images, networks, and
+volumes.
+
+## docker-prune
+
+A less aggressive cleanup script for Docker. It stops any containers
+specified as arguments, then prunes all unused containers, networks, and
+images (with `-a`), and finally prunes all unused volumes.
+
+## git-branch-prune
+
+Deletes local Git branches whose upstream remote branch has been
+removed. It first runs `git fetch --prune` to update remote-tracking
+branches and provides options to force-delete branches or skip the
+confirmation prompt.
+
+## git-clone
+
+Clones a Git repository into an organized directory structure based on
+the repository\'s organization or user. For example, it clones
+`git@github.com:jcouball/scripts.git` into `~/github/jcouball/scripts`.
+
+## git-remotes
+
+Reorganizes local Git repositories in the current directory. It finds
+all subdirectories that are Git repositories, reads their remote
+\'origin\' URL to determine the organization, and moves them into a new
+directory named after that organization (e.g., `_jcouball`).
+
+## git-status
+
+Provides a detailed overview of the state of a Git repository by showing
+the output of three distinct diff commands: changes between the working
+directory and the index (`git diff-files`), the index and HEAD
+(`git diff-index --cached HEAD`), and the working directory and HEAD
+(`git diff-index HEAD`).
+
+## git-wrapped
+
+A wrapper script for the `git` executable, designed for development on
+Git itself. It sets the necessary environment variables
+(`GIT_EXEC_PATH`, `GIT_TEMPLATE_DIR`, etc.) to use a custom build of Git
+instead of the system-installed version.
+
+## launch-keeper
+
+A macOS utility to back up and restore auto-launch configurations. It
+saves a list of login items and copies user-level `LaunchAgents` plists,
+allowing for easy restoration on a new or rebuilt system.
+
+## non-git-subdirs
+
+Scans the subdirectories of the current location and prints the names of
+those that are not part of a Git repository. It is designed to be run
+from a directory that is not itself within a Git work-tree.
+
+## remove-icon-files
+
+A Ruby script that recursively finds and deletes custom macOS icon files
+(`Icon\r`) from a specified directory. It includes options for a dry run
+(to list files without deleting) and logging.
+
+## reset-test
+
+A simple utility script that removes and then recreates the directory
+`~/my_test`, providing a clean slate for testing purposes.
+
+## reuse-ssh-agent
+
+Finds and connects to a running `ssh-agent` process to reuse it for the
+current shell session. If no active agent is found, it starts a new one.
+This script is intended to be sourced in a shell startup file like
+`.zshrc` or `.bashrc`.
+
+## rubocop
+
+A wrapper script that executes the `rubocop` command using the version
+specified in the current project\'s `Gemfile`, ensuring consistent style
+checks.
+
+## ruby-wrapper
+
+A sophisticated wrapper for running a Ruby script from a specific gem in
+an isolated environment. It uses `asdf` to manage the Ruby version and
+`bundler` to manage the gem and its dependencies within a dedicated
+directory (`~/.local/share/<gem-name>`), which it automatically cleans
+monthly.
+
+## ruby-wrapper-list
+
+Lists all the isolated Ruby gem environments that have been created by
+the `ruby-wrapper` script in the `~/.local/share` directory.
+
+## run-until-fail
+
+Executes a given command repeatedly in a loop until it fails (i.e.,
+returns a non-zero exit code). It reports the number of successful runs
+before the failure.
+
+## shell-mode-functions
+
+A collection of POSIX-compatible shell functions
+(`is_interactive_shell`, `is_login_shell`, etc.) to reliably determine
+the operating mode of the current shell. This script is meant to be
+sourced, not executed directly.
+
+## src-clean
+
+A powerful Ruby script for cleaning a source directory by comparing it
+against a target directory. It moves files that are unique to the source
+into the target, and deletes files from the source that are identical to
+their counterparts in the target. Finally, it removes any empty
+subdirectories left behind in the source.
+
+## sshagent
+
+A script containing functions to manage SSH agent connections, with
+special handling for `yubico-agent` on macOS and standard `ssh-agent` on
+Linux. It is intended to be sourced into a shell environment.
+
+## upgrade-all
+
+A comprehensive update script for macOS. It automates the process of
+updating Homebrew, upgrading all installed formulae and casks, cleaning
+up old versions, and upgrading all Mac App Store applications via `mas`.
+
+## xcode-version
+
+A macOS script that reports the installed versions of Xcode and the
+command-line developer tools by querying the `pkgutil` database.

--- a/ai-prompt.erb
+++ b/ai-prompt.erb
@@ -1,0 +1,25 @@
+I have created a project that includes a set of scripts and tools that I find useful
+for various tasks.
+
+I would like to generate a document (scripts.html) which describes the purpose of
+each script in the bin directory. This document should be in html format that is
+compatible with conversion to GitHub markdown using the command `pandoc scripts.html
+-f html -t markdown -o SCRIPTS.md`.
+
+<%=
+  file_patterns = %w[
+      .github/**/*
+      bin/**/*
+      .commitlintrc.yml
+      .gitignore
+      .markdownlint.yml
+      .release-please-manifest.json
+      CHANGELOG.md
+      LICENSE.txt
+      README.md
+      release-please-config.json
+      *.gemspec
+  ]
+
+  project_to_s(file_patterns:)
+%>

--- a/bin/ai-prompt
+++ b/bin/ai-prompt
@@ -1,106 +1,173 @@
 #!/usr/bin/env ruby
 
+require 'stringio'
+
 top_level_dir = `git rev-parse --show-toplevel 2>/dev/null`.chomp
 if top_level_dir.empty? || top_level_dir != Dir.pwd
   puts 'This script must be run from the root of a git repository.'
   exit 1
 end
 
-
-# puts <<~STYLE_GUIDE
-#   # Style Guide
-
-#   For YARD doc:
-#   * Class, method, etc. summaries should not end in a period and should be under 80 characters.
-#   * Longer class, method. etc. descriptions should be in Markdown format.
-#   * All classes must include the “@api public” tag unless asked for a private class.
-#   * All methods should have full YARD docs including a description, params, return (including void), and raises.
-#   * All public methods must include an example.
-#   * All private methods must include the “@api private” tag.
-#   * All methods of a private class must include the “@api private” tag.
-#   * @params should have the name before the type as in “@param name [type] summary”.
-
-#   For Code:
-#   * Unused method argument should be prefixed with an underscore
-#   * Make sure all code will pass all Rubocop rules defined in this configuration: https://github.com/main-branch/main_branch_shared_rubocop_config/blob/main/config/rubocop.yml
-#   * Error messages should be written to stderr
-
-#   For RSpec tests:
-#   * Use 'described_class' to refer to the class in the top level RSpec.describe block.
-
-#   Suggest corrections to code base if it does not follow these conventions.
-# STYLE_GUIDE
-
-def output_file(file)
-  puts "#{file}:"
-  puts
-  puts '==='
-  puts File.read(file).chomp
-  puts
-  puts '==='
-  puts
+unless system('command -v pbcopy > /dev/null 2>&1')
+  warn 'pbcopy not found or not executable. This script is intended for macOS.'
+  exit 1
 end
 
-def ruby_files
-  (
-    Dir.glob('README.md') +
-    Dir.glob("*.gemspec") +
-    Dir.glob('lib/**/*') +
-    Dir.glob('exe/**/*') +
-    Dir.glob('spec/**/*') +
-    Dir.glob('test/**/*') +
-    Dir.glob('tests/**/*')
-  ).reject { |f| File.directory?(f) }
-end
+require 'erb'
+require 'open3'
 
-def git_file?(file)
-  file.start_with?('.git/') || file.include?('/.git/')
-end
+# Defines the context in which the ERB template will be evaluated.
+# You can add instance variables here, and they will be available in your ERB file.
+class TemplateContext
+  def initialize
+    @current_user = ENV['USER'] || 'User'
+  end
 
-def all_files
-  Dir.glob("**/*", File::FNM_DOTMATCH)
-    .reject { |f| git_file?(f) }
-    .reject { |f| File.directory?(f) }
+  def get_binding
+    binding
+  end
+
+  def project_to_s(project_name: Dir.pwd, file_patterns: ruby_project_files)
+    output = StringIO.new
+
+    output << <<~HEADER
+      This is my project '#{project_name}'
+
+      Here are the files from the project delimited by "===":
+
+    HEADER
+
+    files =
+      file_patterns.flat_map do |pattern|
+        Dir.glob(pattern, File::FNM_DOTMATCH)
+          .reject { |f| File.directory?(f) }
+          .reject { |f| git_file?(f) }
+      end
+
+    files.each { |f| output << file_to_s(file: f) }
+
+    output.string
+  end
+
+  def file_to_s(file:)
+    <<~FILE
+      #{file}:
+
+      ===
+      #{File.read(file).chomp}
+      ===
+
+    FILE
+  end
+
+  def ruby_project_files
+    %w[
+      .github/**/*
+      .commitlintrc.yml
+      .markdownlint.yml
+      .release-please-manifest.json
+      .rspec
+      .rubocop.yml
+      CHANGELOG.md
+      Gemfile
+      LICENSE.txt
+      package.json
+      Rakefile
+      README.md
+      release-please-config.json
+      *.gemspec
+      bin/**/*
+      exe/**/*
+      lib/**/*
+      spec/**/*
+      test/**/*
+      tests/**/*
+    ].freeze
+  end
+
+  def all_files
+    %w[**/*].freeze
+  end
+
+  def git_file?(file)
+    file.start_with?('.git/') || file.include?('/.git/')
+  end
 end
 
 def usage
   puts <<~USAGE
-    Usage: ai-prompt [--all|--ruby|--help|-h]
+    Usage: ai-prompt [--help|-h] [<erb_file>]
 
-    --all:     Show all files in the project.
-    --ruby:    Show only Ruby files in the project.
-    --help|-h: Show this help message.
+    Generate an AI prompt from an ERB template and copy it to the clipboard
+
+    <erb_file>: The ERB template file to process. Defaults to 'ai-prompt.erb'.
+    --help|-h:  Show this help message.
+
+    ERB methods available:
+      <%=
+        # Returns a formatted string of the project name and files
+        project_name = 'Project Name'      # Default is current directory name
+        file_patterns = ruby_project_files # Default is common Ruby project files
+        project_to_s(project_name:, file_patterns:)
+      %>
+      <%=
+        # Return a formatted string of a single file's contents
+        file_to_s(file:)    # Outputs the contents of a single file
+      %>
+      <%
+        ruby_project_files # An array of glob patterns for common Ruby files
+        all_files          # An array of glob patterns for all files
+      %>
+
+    Example ai-prompt.erb file:
+      I am writing a Ruby gem that provides a ruby interface to the git command line tool.
+      See the project code below.
+
+      Write an announcement for the architecture redesign of the gem to be
+      placed in the README.md file in the section "Architecture Redesign
+      Announcement". This announcement should be short, concise, and to the
+      point and should introduce and link to the redesign documents found in
+      the project's `redesign` directory.
+
+      <%=
+        file_patterns = %w[
+          Gemfile
+          Rakefile
+          README.md
+          *.gemspec
+          lib/**/*
+          redesign/*
+        ]
+
+        output_project(file_patterns:)
+      %>
   USAGE
 end
 
-files = []
-
-if ARGV.empty?
+if ARGV[0] == '--help' || ARGV[0] == '-h'
   usage
-else
-  if ARGV[0] == '--all'
-    files = all_files
-  elsif ARGV[0] == '--ruby'
-    files = ruby_files
-  elsif ARGV[0] == '--help' || ARGV[0] == '-h'
-    usage
-  else
-
-    warn "Unknown argument '#{ARGV[0]}'."
-    usage
-    exit 1
-  end
-  all_files.select! { |f| ARGV.include?(f) }
+  exit 0
 end
 
-unless files.empty?
-  project_name = File.basename(Dir.pwd)
+erb_file_name = ARGV[0] || 'ai-prompt.erb'
 
-  puts <<~HEADING
-    This is my project '#{project_name}'.
-  HEADING
+begin
+  erb_template_content = File.read(erb_file_name)
+rescue => e
+  puts "Error reading file: #{e.message}"
+  exit 1
+end
 
-  puts 'Here are the files from the project delimited by "==="'
-  puts
-  files.each { |f| output_file(f) }
+context = TemplateContext.new
+renderer = ERB.new(erb_template_content, trim_mode: "-") # trim_mode cleans up whitespace
+processed_output = renderer.result(context.get_binding)
+
+begin
+  IO.popen('pbcopy', 'w') do |pipe|
+    pipe.write(processed_output)
+  end
+  puts "Prompt has been output to the clipboard."
+rescue Errno::ENOENT
+  puts "Error: 'pbcopy' command not found. This script is intended for macOS."
+  exit 1
 end

--- a/bin/upgrade-all
+++ b/bin/upgrade-all
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Update Homebrew, and upgrade Homebrew packages and Mac App Store apps
+
+set -euo pipefail
+
+box_out() {
+  local s="$1"
+
+  # The length of the string plus padding
+  local len=$((${#s} + 2))
+
+  # Create the top, middle, and bottom parts of the box using heavy lines.
+  local top="┏$(printf '━%.0s' $(seq 1 $len))┓"
+  local middle="┃ $s ┃"
+  local bottom="┗$(printf '━%.0s' $(seq 1 $len))┛"
+
+  # Print the box to the screen.
+  echo "$top"
+  echo "$middle"
+  echo "$bottom"
+}
+
+box_out "Update Homebrew"
+brew update
+echo "DONE"
+echo
+
+box_out "Upgrade installed formulae"
+brew upgrade
+echo "DONE"
+echo
+
+box_out "Cleanup old versions"
+brew cleanup
+echo "DONE"
+echo
+
+box_out "Upgrade Mac App Store apps"
+mas upgrade
+echo "DONE"
+echo
+
+echo
+echo "ALL UPGRADES COMPLETED"


### PR DESCRIPTION
Adds the following scripts:

## ai-prompt

A Ruby script that generates a prompt for an AI model from an ERB
template. It reads a template file (e.g., `ai-prompt.erb`), processes it
to include project file contents, and copies the resulting prompt to the
macOS clipboard using `pbcopy`. It is designed to be run from the root
of a Git repository.

## upgrade-all

A comprehensive update script for macOS. It automates the process of
updating Homebrew, upgrading all installed formulae and casks, cleaning
up old versions, and upgrading all Mac App Store applications via `mas`.