### PR TITLE
Ensure that all mac store apps are updated

### DIFF
--- a/bin/upgrade-all
+++ b/bin/upgrade-all
@@ -37,7 +37,16 @@ echo "DONE"
 echo
 
 box_out "Upgrade Mac App Store apps"
-mas upgrade
+mas list | while IFS= read -r line; do
+  app_id=$(echo "$line" | awk '{print $1}')
+  app_name=$(echo "$line" | cut -d' ' -f2-)
+
+  if [[ -n "$app_id" ]]; then
+    echo -n "Attempting to upgrade '$app_name' (ID: $app_id)..."
+    mas upgrade --verbose "$app_id"
+    echo "DONE"
+  fi
+done
 echo "DONE"
 echo
 


### PR DESCRIPTION
Call mas upgrade for every installed mas application.

Just calling `mas upgrade` does not upgrade apps when only
the version is updated.