### PR TITLE
Fix display of Mac App Store app name

### DIFF
--- a/bin/upgrade-all
+++ b/bin/upgrade-all
@@ -39,13 +39,16 @@ echo
 box_out "Upgrade Mac App Store apps"
 mas list | while IFS= read -r line; do
   app_id=$(echo "$line" | awk '{print $1}')
-  app_name=$(echo "$line" | cut -d' ' -f2-)
+
+  # Extract the part after the ID and then clean up spaces
+  # This pattern matches the App ID and then captures everything until the last opening parenthesis
+  app_name=$(echo "$line" | sed -E 's/^[0-9]+[[:space:]]*(.*)[[:space:]]+\([0-9]+\.[0-9.]+\)$/\1/' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
   if [[ -n "$app_id" ]]; then
     echo -n "Attempting to upgrade '$app_name' (ID: $app_id)..."
     mas upgrade --verbose "$app_id"
-    echo "DONE"
   fi
+  echo "OK"
 done
 echo "DONE"
 echo


### PR DESCRIPTION
Improves the extraction and display of the Mac App Store app name by refining the parsing logic to handle spaces and formatting correctly.