### PR TITLE
Make `brew upgrade` greedy and rename upgrade-all script

### DIFF
--- a/bin/brew-upgrade-all
+++ b/bin/brew-upgrade-all
@@ -1,42 +1,37 @@
 #!/bin/bash
 
-# Update Homebrew, and upgrade Homebrew packages and Mac App Store apps
+# Update Homebrew, upgrade Homebrew packages, and upgrade Mac App Store apps
 
 set -euo pipefail
 
-box_out() {
+notify() {
   local s="$1"
 
-  # The length of the string plus padding
   local len=$((${#s} + 2))
 
-  # Create the top, middle, and bottom parts of the box using heavy lines.
   local top="┏$(printf '━%.0s' $(seq 1 $len))┓"
   local middle="┃ $s ┃"
   local bottom="┗$(printf '━%.0s' $(seq 1 $len))┛"
 
-  # Print the box to the screen.
+  echo ""
   echo "$top"
   echo "$middle"
   echo "$bottom"
 }
 
-box_out "Update Homebrew"
+notify "Updating Homebrew"
 brew update
 echo "DONE"
-echo
 
-box_out "Upgrade installed formulae"
-brew upgrade
+notify "Upgrading installed Homebrew packages"
+brew upgrade --greedy
 echo "DONE"
-echo
 
-box_out "Cleanup old versions"
+notify "Cleaning up old Homebrew packages"
 brew cleanup
 echo "DONE"
-echo
 
-box_out "Upgrade Mac App Store apps"
+notify "Upgrading Mac App Store apps"
 mas list | while IFS= read -r line; do
   app_id=$(echo "$line" | awk '{print $1}')
 
@@ -51,7 +46,5 @@ mas list | while IFS= read -r line; do
   echo "OK"
 done
 echo "DONE"
-echo
 
-echo
-echo "ALL UPGRADES COMPLETED"
+notify "ALL UPGRADES COMPLETED"


### PR DESCRIPTION
Update the upgrade process to ensure all out-of-date Homebrew packages are upgraded. Rename the upgrade-all script to `brew-upgrade-all`, introducing a breaking change in the upgrade method.