### PR TITLE
fix: fix typo in the help output of the ai-prompt command

### DIFF
--- a/bin/ai-prompt
+++ b/bin/ai-prompt
@@ -139,7 +139,7 @@ def usage
           redesign/*
         ]
 
-        output_project(file_patterns:)
+        project_to_s(file_patterns:)
       %>
   USAGE
 end


### PR DESCRIPTION
The `output_project` method was renamed to `project_to_s` but the help text was not updated.