### PR TITLE
Give a reminder why the brew_needs_update function is used

### DIFF
--- a/bin/brew-upgrade-all
+++ b/bin/brew-upgrade-all
@@ -35,6 +35,8 @@ brew_needs_update() {
 
 update_brew() {
   notify "Updating Homebrew"
+  # Silently check to see if brew needs to be updated to avoid `brew update`
+  # outputting "Already up-to-date."
   if brew_needs_update; then
     brew update
   fi


### PR DESCRIPTION
I am tired of my AI reviewer always telling me that brew_needs_update is not needed.

Hopefully putting this comment in will stop it from suggesting to remove this function.