### PR TITLE
Update build dependencies

### DIFF
--- a/.github/workflows/enforce_conventional_commits.yml
+++ b/.github/workflows/enforce_conventional_commits.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: { fetch-depth: 0 }
 
       - name: Check Commit Messages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
             storage.googleapis.com:443
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         # Fetch all history for all tags and branches
         with:
           fetch-depth: 0


### PR DESCRIPTION
Upgrade the GitHub Actions checkout action from v4 to v6 to ensure compatibility and access to the latest features.