### PR TITLE
feat: add github-list-repos-with-secret and github-set-repo-secret scripts

### DIFF
--- a/bin/github-list-repos-with-secret
+++ b/bin/github-list-repos-with-secret
@@ -1,0 +1,199 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'open3'
+require 'json'
+
+SCRIPT_NAME = File.basename($PROGRAM_NAME)
+
+def usage
+  <<~USAGE
+    Usage: #{SCRIPT_NAME} OWNER SECRET_NAME
+
+    Lists all repositories owned by OWNER (a user or organization) that have
+    an Actions repository secret with the given name.
+
+    Only repository secrets are checked (Settings > Secrets and variables >
+    Actions > Repository secrets).  Organization-level or environment-level
+    secrets are not considered.
+
+    ARGUMENTS
+      OWNER        GitHub username or organization name whose repositories will
+                   be scanned.
+      SECRET_NAME  The name of the Actions secret to search for.
+
+    OUTPUT
+      One "owner/repo" name per line for each repository that has the secret.
+      Progress and error messages are written to stderr so stdout can be piped
+      directly into other tools (e.g. #{SCRIPT_NAME.sub('list', 'set')}).
+
+    ENVIRONMENT
+      GITHUB_TOKEN  Required. A GitHub Personal Access Token (PAT) used to
+                    authenticate API requests.  The token must have the
+                    following permissions for each target repository:
+                      - 'repo' scope (includes private repositories)
+                      OR
+                      - 'public_repo' scope (public repositories only)
+                    The token must also have read access to Actions secrets.
+
+    PREREQUISITES
+      The 'gh' CLI (https://cli.github.com) must be installed and available in
+      your PATH.
+
+    EXAMPLES
+      List all jcouball repositories that have AUTO_RELEASE_TOKEN:
+
+        #{SCRIPT_NAME} jcouball AUTO_RELEASE_TOKEN
+
+      Pipe directly into github-set-repo-secret to update the secret on every
+      matching repository:
+
+        #{SCRIPT_NAME} jcouball OLD_SECRET | \\
+          github-set-repo-secret OLD_SECRET new_value
+
+      Check an organization:
+
+        #{SCRIPT_NAME} my-org DEPLOY_KEY
+
+    NOTES
+      - The GitHub API returns a 200 response (with metadata but NOT the secret
+        value) when a secret exists, and 404 when it does not.  The actual
+        secret value is never exposed.
+      - Repositories for which the token lacks read access are reported on
+        stderr and skipped.
+      - Exit code is 0 on success (even if no repositories match).
+        Exit code is 1 if a fatal error prevents the scan from running.
+  USAGE
+end
+
+# Print an error message to stderr.
+def error(message)
+  warn "#{SCRIPT_NAME}: error: #{message}"
+end
+
+# Print a progress/informational message to stderr.
+def info(message)
+  warn message
+end
+
+# Verify that 'gh' is available and GITHUB_TOKEN is set.
+def check_prerequisites
+  unless system('command -v gh > /dev/null 2>&1')
+    error "'gh' CLI is not installed or not found in PATH. See https://cli.github.com"
+    exit 1
+  end
+
+  token = ENV['GITHUB_TOKEN']
+  if token.nil? || token.strip.empty?
+    error 'GITHUB_TOKEN environment variable is not set or is empty.'
+    exit 1
+  end
+end
+
+# Return an env hash suitable for subprocess calls that maps GITHUB_TOKEN onto
+# the GH_TOKEN variable that the gh CLI actually reads.
+def gh_env
+  ENV.to_h.merge('GH_TOKEN' => ENV.fetch('GITHUB_TOKEN'))
+end
+
+# Fetch all repository names (owner/repo) for the given owner.
+# Exits on failure.
+def list_repos(owner)
+  out, stderr, status = Open3.capture3(
+    gh_env,
+    'gh', 'repo', 'list', owner,
+    '--limit', '1000',
+    '--json', 'nameWithOwner',
+    '-q', '.[].nameWithOwner'
+  )
+
+  unless status.success?
+    error "failed to list repositories for '#{owner}': #{stderr.strip}"
+    exit 1
+  end
+
+  repos = out.lines(chomp: true).map(&:strip).reject(&:empty?)
+
+  if repos.empty?
+    info "No repositories found for '#{owner}'."
+    exit 0
+  end
+
+  repos
+end
+
+# Return true if the named secret exists on the given repo, false if it does
+# not, or nil if the check itself failed (e.g. permission denied).
+def secret_exists?(repo, secret_name)
+  _out, _stderr, status = Open3.capture3(
+    gh_env,
+    'gh', 'api',
+    "/repos/#{repo}/actions/secrets/#{secret_name}",
+    '--silent'
+  )
+
+  case status.exitstatus
+  when 0    then true   # 200 OK – secret exists
+  when 1    then false  # gh maps 404 → exit 1
+  else           nil    # unexpected error
+  end
+end
+
+# ── Argument handling ──────────────────────────────────────────────────────────
+
+if ARGV.include?('-h') || ARGV.include?('--help')
+  puts usage
+  exit 0
+end
+
+if ARGV.empty?
+  puts usage
+  exit 1
+end
+
+if ARGV.length != 2
+  error "expected 2 arguments (OWNER and SECRET_NAME), got #{ARGV.length}."
+  warn "Run '#{SCRIPT_NAME} --help' for usage."
+  exit 1
+end
+
+owner, secret_name = ARGV
+
+# ── Validate prerequisites ─────────────────────────────────────────────────────
+
+check_prerequisites
+
+# ── Fetch repository list ──────────────────────────────────────────────────────
+
+info "Fetching repository list for '#{owner}'..."
+repos = list_repos(owner)
+noun = repos.length == 1 ? 'repository' : 'repositories'
+info "Checking #{repos.length} #{noun} for secret '#{secret_name}'..."
+
+# ── Check each repository ──────────────────────────────────────────────────────
+
+matches = []
+errors  = []
+
+repos.each do |repo|
+  result = secret_exists?(repo, secret_name)
+  case result
+  when true  then matches << repo
+  when false then nil # secret absent – expected, no output needed
+  when nil   then errors << repo
+  end
+end
+
+# ── Output results ─────────────────────────────────────────────────────────────
+
+if errors.any?
+  info "\nCould not check the following #{errors.length == 1 ? 'repository' : 'repositories'} (permission error or API failure):"
+  errors.each { |r| info "  #{r}" }
+end
+
+if matches.empty?
+  info "\nNo repositories found with secret '#{secret_name}'."
+else
+  info "\n#{matches.length} #{matches.length == 1 ? 'repository' : 'repositories'} with secret '#{secret_name}':"
+  matches.each { |r| puts r }
+end

--- a/bin/github-set-repo-secret
+++ b/bin/github-set-repo-secret
@@ -1,0 +1,171 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'open3'
+
+SCRIPT_NAME = File.basename($PROGRAM_NAME)
+
+def usage
+  <<~USAGE
+    Usage: #{SCRIPT_NAME} SECRET_NAME SECRET_VALUE
+
+    Sets a GitHub Actions repository secret to the given value for each repository
+    listed on stdin.
+
+    ARGUMENTS
+      SECRET_NAME   The name of the Actions secret to create or update.
+                    Must be a valid GitHub secret name (letters, numbers, underscores;
+                    cannot start with GITHUB_).
+      SECRET_VALUE  The plaintext value to assign to the secret. The value is
+                    encrypted locally before being sent to the GitHub API.
+
+    STDIN
+      A newline-delimited list of GitHub repository names in "owner/repo" format.
+      Blank lines and lines beginning with '#' are ignored and may be used for
+      comments.
+
+    ENVIRONMENT
+      GITHUB_TOKEN  Required. A GitHub Personal Access Token (PAT) used to
+                    authenticate API requests.  The token must have the following
+                    permissions for each target repository:
+                      - 'repo' scope (includes private repositories)
+                      OR
+                      - 'public_repo' scope (public repositories only)
+                    The token must also have write access to Actions secrets
+                    (Settings > Secrets and variables > Actions).
+
+    PREREQUISITES
+      The 'gh' CLI (https://cli.github.com) must be installed and available in
+      your PATH.  The 'gh' CLI handles the required libsodium (sealed box)
+      encryption of the secret value before it is sent to the GitHub API.
+
+    EXAMPLES
+      Set a secret for every repository listed in a file:
+
+        cat repos.txt | #{SCRIPT_NAME} MY_SECRET supersecretvalue
+
+      Set a secret for all repositories owned by a user (requires gh):
+
+        gh repo list jcouball --json nameWithOwner -q '.[].nameWithOwner' | \\
+          #{SCRIPT_NAME} MY_SECRET supersecretvalue
+
+      Set a secret for a few repositories given inline via printf:
+
+        printf 'jcouball/repo1\\njcouball/repo2\\n' | \\
+          #{SCRIPT_NAME} MY_SECRET supersecretvalue
+
+      Use a token stored in a file (e.g. ~/.github_token):
+
+        GITHUB_TOKEN=$(cat ~/.github_token) #{SCRIPT_NAME} MY_SECRET value < repos.txt
+
+    NOTES
+      - The secret is created if it does not exist, or silently updated if it does.
+      - Repository names are validated for the expected "owner/repo" format before
+        any API calls are made.
+      - Exit code is 0 when all secrets are updated successfully, 1 otherwise.
+  USAGE
+end
+
+# Print an error message to stderr, prefixed with the script name.
+def error(message)
+  warn "#{SCRIPT_NAME}: error: #{message}"
+end
+
+# Verify that the 'gh' CLI is present and that GITHUB_TOKEN is set.
+def check_prerequisites
+  unless system('command -v gh > /dev/null 2>&1')
+    error "'gh' CLI is not installed or not found in PATH. See https://cli.github.com"
+    exit 1
+  end
+
+  token = ENV['GITHUB_TOKEN']
+  if token.nil? || token.strip.empty?
+    error 'GITHUB_TOKEN environment variable is not set or is empty.'
+    exit 1
+  end
+end
+
+# Set the secret on one repository. Returns true on success, false on failure.
+def set_secret(repo, secret_name, secret_value, env)
+  _out, stderr, status = Open3.capture3(
+    env,
+    'gh', 'secret', 'set', secret_name,
+    '--body', secret_value,
+    '--repo', repo
+  )
+
+  if status.success?
+    puts "  [OK]   #{repo}"
+    true
+  else
+    warn "  [FAIL] #{repo}: #{stderr.strip}"
+    false
+  end
+end
+
+# ── Argument handling ──────────────────────────────────────────────────────────
+
+if ARGV.include?('-h') || ARGV.include?('--help')
+  puts usage
+  exit 0
+end
+
+if ARGV.empty?
+  puts usage
+  exit 1
+end
+
+if ARGV.length != 2
+  error "expected 2 arguments (SECRET_NAME and SECRET_VALUE), got #{ARGV.length}."
+  warn "Run '#{SCRIPT_NAME} --help' for usage."
+  exit 1
+end
+
+secret_name, secret_value = ARGV
+
+# ── Validate prerequisites ─────────────────────────────────────────────────────
+
+check_prerequisites
+
+# ── Read and validate repositories from stdin ──────────────────────────────────
+
+if $stdin.tty?
+  error 'no input on stdin. Pipe a newline-delimited list of "owner/repo" names.'
+  warn "Run '#{SCRIPT_NAME} --help' for usage."
+  exit 1
+end
+
+repos =
+  $stdin
+  .readlines(chomp: true)
+  .map(&:strip)
+  .reject { |line| line.empty? || line.start_with?('#') }
+
+if repos.empty?
+  error 'no repositories found in stdin after filtering blank lines and comments.'
+  exit 1
+end
+
+invalid = repos.reject { |r| r.match?(%r{\A[\w.\-]+/[\w.\-]+\z}) }
+if invalid.any?
+  error "the following lines are not valid \"owner/repo\" names:"
+  invalid.each { |r| warn "  #{r}" }
+  exit 1
+end
+
+# ── Set the secret on each repository ─────────────────────────────────────────
+
+noun = repos.length == 1 ? 'repository' : 'repositories'
+puts "Setting secret '#{secret_name}' on #{repos.length} #{noun}..."
+
+# gh uses GH_TOKEN; map GITHUB_TOKEN onto it so the caller only needs one var.
+gh_env = ENV.to_h.merge('GH_TOKEN' => ENV.fetch('GITHUB_TOKEN'))
+
+failures = repos.count { |repo| !set_secret(repo, secret_name, secret_value, gh_env) }
+
+if failures.zero?
+  puts "\nDone. All #{repos.length} #{noun} updated successfully."
+else
+  warn "\nDone with errors: #{failures} of #{repos.length} #{noun} failed."
+  exit 1
+end


### PR DESCRIPTION
## Summary

Add two Ruby scripts for managing GitHub Actions repository secrets across multiple repositories.

## New Scripts

### `github-list-repos-with-secret`

Scans all repositories owned by a user or organization and prints the names of those that have a specific named Actions secret (Settings > Secrets and variables > Actions > Repository secrets).

```
github-list-repos-with-secret OWNER SECRET_NAME
```

- Output is one `owner/repo` per line, suitable for piping
- Progress and errors go to stderr so stdout can be piped cleanly
- Requires the `gh` CLI and a `GITHUB_TOKEN` env var

### `github-set-repo-secret`

Reads repository names from stdin and sets a named Actions secret on each one using the `gh` CLI (which handles libsodium encryption locally before sending to the API).

```
printf 'owner/repo1\nowner/repo2\n' | github-set-repo-secret SECRET_NAME secret_value
```

- Accepts `owner/repo` lines from stdin; ignores blank lines and `#` comments
- Creates the secret if it doesn't exist, silently updates it if it does
- Requires the `gh` CLI and a `GITHUB_TOKEN` env var

## Composability

The two scripts are designed to work together in a pipeline:

```sh
github-list-repos-with-secret jcouball OLD_SECRET | \
  github-set-repo-secret NEW_SECRET new_value
```
