### PR TITLE
ci: update ci build dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Secure runner
-        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           disable-sudo: true
           egress-policy: block
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0
 
       - name: Create release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.AUTO_RELEASE_TOKEN }}


### PR DESCRIPTION
Update GitHub Actions used in the release workflow:

- `step-security/harden-runner`: v2.11.1 → v2.19.0
- `googleapis/release-please-action`: v4 → v5