### PR TITLE
build(dependencies): update dependencies for all GitHub Actions workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Secure runner
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        uses: step-security/harden-runner@v2
         with:
           disable-sudo: true
           egress-policy: block


### PR DESCRIPTION
## Summary

Update GitHub Actions workflow dependencies to use the latest floating major version tags.

### Changes

- `step-security/harden-runner`: Converted SHA pin (`8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0`) to floating major version tag `@v2`. Latest release is v2.19.0.

### No changes needed

- `actions/checkout@v6` — already on latest major (v6.0.2)
- `wagoid/commitlint-github-action@v6` — already on latest major (v6.2.1)
- `googleapis/release-please-action@v5` — already on latest major (v5.0.0)