### PR TITLE
fix: remove unsupported --all flag from brew bundle dump

### DIFF
--- a/bin/brew-bundle-dump
+++ b/bin/brew-bundle-dump
@@ -30,5 +30,5 @@ fi
 (
   export PATH="$path_to_use"
   set -x
-  brew bundle dump --describe --global --all --force
+  brew bundle dump --describe --global --force
 )


### PR DESCRIPTION
The `--all` flag is no longer supported by `brew bundle dump` and causes an error when used. This PR removes it from the `brew-bundle-dump` script.