### PR TITLE
Fix asdf-update-tools for Homebrew-based asdf install

### DIFF
--- a/bin/asdf-update-tools
+++ b/bin/asdf-update-tools
@@ -75,13 +75,9 @@ process_tool() {
 
 # --- Main Execution ---
 main() {
-  # --- Source asdf.sh to load the asdf function ---
-  local ASDF_DIR="${ASDF_DIR:-$HOME/.asdf}"
-  if [ -f "$ASDF_DIR/asdf.sh" ]; then
-    # shellcheck source=/dev/null
-    . "$ASDF_DIR/asdf.sh"
-  else
-    echo "Error: asdf.sh not found in $ASDF_DIR. Please check your asdf installation." >&2
+  # --- Ensure asdf is available ---
+  if ! command -v asdf &>/dev/null; then
+    echo "Error: asdf not found. Please check your asdf installation." >&2
     exit 1
   fi
 


### PR DESCRIPTION
## Problem

`asdf-update-tools` was failing with:

```
Error: asdf.sh not found in /Users/james/.asdf. Please check your asdf installation.
```

The script unconditionally looked for `~/.asdf/asdf.sh` to source before running. This file only exists in older, source-based asdf installations.

## Solution

Modern asdf (v0.14+, including Homebrew-distributed builds) ships as a standalone binary in `PATH` — no `asdf.sh` file is needed. Replace the `asdf.sh` file check with a simple `command -v asdf` check to verify asdf is available in `PATH`.

This drops support for older source-based asdf installs.